### PR TITLE
Removing extraneous hard dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,9 +54,16 @@
 		"material-ui": "^0.17.0 || ^0.18.0",
 		"react": "^15.0.0",
 		"react-dom": "^15.0.0",
-		"react-tap-event-plugin": "^1.0.0 || ^2.0.0"
+		"react-tap-event-plugin": "^1.0.0 || ^2.0.0",
+		"prop-types": "^15.5.10"
 	},
 	"devDependencies": {
+		"material-ui": "^0.18.3",
+		"react-router-dom": "^4.1.1",
+		"react-tap-event-plugin": "^2.0.1",
+		"babel-runtime": "^6.23.0",
+		"react": "^15.0.0",
+		"react-dom": "^15.0.0",
 		"@namics/eslint-config": "^2.0.0",
 		"babel-cli": "^6.18.0",
 		"babel-core": "^6.18.2",
@@ -83,15 +90,5 @@
 		"rimraf": "^2.5.4",
 		"sinon": "^1.17.6",
 		"webpack": "^1.13.3"
-	},
-	"dependencies": {
-		"babel-runtime": "^6.23.0",
-		"material-ui": "^0.18.3",
-		"prop-types": "^15.5.10",
-		"react": "^15.5.4",
-		"react-dom": "^15.5.4",
-		"react-router-dom": "^4.1.1",
-		"react-tap-event-plugin": "^2.0.1",
-		"simple-assign": "^0.1.0"
 	}
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1604,6 +1604,14 @@ coveralls@^2.11.15:
     minimist "1.2.0"
     request "2.79.0"
 
+create-react-class@^15.6.0:
+  version "15.6.2"
+  resolved "https://registry.yarnpkg.com/create-react-class/-/create-react-class-15.6.2.tgz#cf1ed15f12aad7f14ef5f2dfe05e6c42f91ef02a"
+  dependencies:
+    fbjs "^0.8.9"
+    loose-envify "^1.3.1"
+    object-assign "^4.1.1"
+
 cross-spawn@4.0.2:
   version "4.0.2"
   resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-4.0.2.tgz#7b9247621c23adfdd3856004a823cbe397424d41"
@@ -4321,7 +4329,7 @@ object-assign@4.1.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/object-assign/-/object-assign-4.1.0.tgz#7a3b3d0e98063d43f4c03f2e8ae6cd51a86883a0"
 
-object-assign@^4.0.1, object-assign@^4.1.0:
+object-assign@^4.0.1, object-assign@^4.1.0, object-assign@^4.1.1:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/object-assign/-/object-assign-4.1.1.tgz#2109adc7965887cfc05cbbd442cac8bfbb360863"
 
@@ -4892,7 +4900,7 @@ promise@7.1.1, promise@^7.1.1:
   dependencies:
     asap "~2.0.3"
 
-prop-types@^15.5.10, prop-types@^15.5.4, prop-types@^15.5.6, prop-types@^15.5.7, prop-types@~15.5.7:
+prop-types@^15.5.10, prop-types@^15.5.4, prop-types@^15.5.6, prop-types@^15.5.7:
   version "15.5.10"
   resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.5.10.tgz#2797dfc3126182e3a95e3dfbb2e893ddd7456154"
   dependencies:
@@ -5007,14 +5015,14 @@ react-dev-utils@^0.3.0:
     sockjs-client "1.0.3"
     strip-ansi "3.0.1"
 
-react-dom@^15.5.4:
-  version "15.5.4"
-  resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-15.5.4.tgz#ba0c28786fd52ed7e4f2135fe0288d462aef93da"
+react-dom@^15.0.0:
+  version "15.6.2"
+  resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-15.6.2.tgz#41cfadf693b757faf2708443a1d1fd5a02bef730"
   dependencies:
     fbjs "^0.8.9"
     loose-envify "^1.1.0"
     object-assign "^4.1.0"
-    prop-types "~15.5.7"
+    prop-types "^15.5.10"
 
 react-event-listener@^0.4.5:
   version "0.4.5"
@@ -5119,14 +5127,15 @@ react-transition-group@^1.1.2:
     prop-types "^15.5.6"
     warning "^3.0.0"
 
-react@^15.5.4:
-  version "15.5.4"
-  resolved "https://registry.yarnpkg.com/react/-/react-15.5.4.tgz#fa83eb01506ab237cdc1c8c3b1cea8de012bf047"
+react@^15.0.0:
+  version "15.6.2"
+  resolved "https://registry.yarnpkg.com/react/-/react-15.6.2.tgz#dba0434ab439cfe82f108f0f511663908179aa72"
   dependencies:
+    create-react-class "^15.6.0"
     fbjs "^0.8.9"
     loose-envify "^1.1.0"
     object-assign "^4.1.0"
-    prop-types "^15.5.7"
+    prop-types "^15.5.10"
 
 read-pkg-up@^1.0.1:
   version "1.0.1"


### PR DESCRIPTION
Currently installing react-speed-dial from npm results in a bunch of extraneous dependencies being installed, this fixes it!